### PR TITLE
Initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,13 +135,7 @@ publish/
 *.publishproj
 
 # NuGet Packages
-*.nupkg
-# The packages folder can be ignored because of Package Restore
-**/packages/*
-# except build/, which is used as an MSBuild target.
-!**/packages/build/
-# Uncomment if necessary however generally it will be regenerated when needed
-#!**/packages/repositories.config
+packages/
 
 # Windows Azure Build Output
 csx/
@@ -194,3 +188,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# ASP.NET 5
+project.lock.json

--- a/IdentityServer4.AccessTokenValidation.sln
+++ b/IdentityServer4.AccessTokenValidation.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".root", ".root", "{AFEEAB80-9941-4D14-B112-0E31CCC4F127}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		global.json = global.json
+		LICENSE = LICENSE
+		NuGet.Config = NuGet.Config
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IdentityServer4.AccessTokenValidation", "src\IdentityServer4.AccessTokenValidation\IdentityServer4.AccessTokenValidation.xproj", "{11600DF7-FC1F-4728-AFB0-5BD6D90A2645}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IdentityServer4.AccessTokenValidation.Tests", "tests\IdentityServer4.AccessTokenValidation.Tests\IdentityServer4.AccessTokenValidation.Tests.xproj", "{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11600DF7-FC1F-4728-AFB0-5BD6D90A2645}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11600DF7-FC1F-4728-AFB0-5BD6D90A2645}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11600DF7-FC1F-4728-AFB0-5BD6D90A2645}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11600DF7-FC1F-4728-AFB0-5BD6D90A2645}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/IdentityServer4.AccessTokenValidation.sln
+++ b/IdentityServer4.AccessTokenValidation.sln
@@ -16,6 +16,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IdentityServer4.AccessToken
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IdentityServer4.AccessTokenValidation.Tests", "tests\IdentityServer4.AccessTokenValidation.Tests\IdentityServer4.AccessTokenValidation.Tests.xproj", "{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MvcSample", "samples\MvcSample\MvcSample.xproj", "{8563575B-BBB5-49A7-9535-E6B345736DD1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".samples", ".samples", "{2CA05351-77BF-4D40-8B53-99EBD398CC68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,8 +34,15 @@ Global
 		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26ABDE45-0F06-41C2-B38E-86AC35DB38C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8563575B-BBB5-49A7-9535-E6B345736DD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8563575B-BBB5-49A7-9535-E6B345736DD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8563575B-BBB5-49A7-9535-E6B345736DD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8563575B-BBB5-49A7-9535-E6B345736DD1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8563575B-BBB5-49A7-9535-E6B345736DD1} = {2CA05351-77BF-4D40-8B53-99EBD398CC68}
 	EndGlobalSection
 EndGlobal

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/global.json
+++ b/global.json
@@ -1,4 +1,5 @@
 {
+  "projects": [ "src", "samples" ],
   "sdk": {
     "version": "1.0.0-rc1-final"
   }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "sdk": {
+    "version": "1.0.0-rc1-final"
+  }
+}

--- a/samples/MvcSample/Controllers/ValuesController.cs
+++ b/samples/MvcSample/Controllers/ValuesController.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNet.Authorization;
+using Microsoft.AspNet.Mvc;
+
+namespace MvcSample.Controllers
+{
+    [Authorize]
+    [Route("values")]
+    public class ValuesController : Controller
+    {
+        [HttpGet]
+        public string[] GetValues()
+        {
+            return new[]
+            {
+                "value 1",
+                "value 2"
+            };
+        }
+    }
+}

--- a/samples/MvcSample/MvcSample.xproj
+++ b/samples/MvcSample/MvcSample.xproj
@@ -6,16 +6,14 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>26abde45-0f06-41c2-b38e-86ac35db38c3</ProjectGuid>
-    <RootNamespace>IdentityServer4.AccessTokenValidation.Tests</RootNamespace>
+    <ProjectGuid>8563575b-bbb5-49a7-9535-e6b345736dd1</ProjectGuid>
+    <RootNamespace>MvcSample</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>62535</DevelopmentServerPort>
   </PropertyGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/samples/MvcSample/Startup.cs
+++ b/samples/MvcSample/Startup.cs
@@ -25,6 +25,8 @@ namespace MvcSample
 
             var introceptionOptions = new IntrospectionEndpointOptions
             {
+                ScopeName = "read",
+                ScopeSecret = "secret",
                 ValidationResultCacheDuration = TimeSpan.FromSeconds(30)
             };
 

--- a/samples/MvcSample/Startup.cs
+++ b/samples/MvcSample/Startup.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.AspNet.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using IdentityServer4.AccessTokenValidation;
+
+namespace MvcSample
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddAccessTokenValidationWithCaching();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            var identityServerBearerTokenOptions = new IdentityServerBearerTokenOptions
+            {
+                Authority = "http://localhost:44300/",
+                AutomaticAuthenticate = true,
+                RequiredScopes = new[] { "read", "write" },
+                PreserveAccessToken = true
+            };
+
+            var introceptionOptions = new IntrospectionEndpointOptions
+            {
+                ValidationResultCacheDuration = TimeSpan.FromSeconds(30)
+            };
+
+            app.UseIdentityServerBearerTokenAuthentication(identityServerBearerTokenOptions, introceptionOptions);
+            app.UseMvc();
+        }
+    }
+}

--- a/samples/MvcSample/hosting.json
+++ b/samples/MvcSample/hosting.json
@@ -1,0 +1,4 @@
+﻿{
+  "server": "Microsoft.AspNet.Server.Kestrel",
+  "server.urls": "http://localhost:5000"
+}

--- a/samples/MvcSample/project.json
+++ b/samples/MvcSample/project.json
@@ -1,0 +1,32 @@
+﻿{
+  "webroot": "wwwroot",
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
+    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
+    "IdentityServer4.AccessTokenValidation": ""
+  },
+
+  "commands": {
+    "web": "Microsoft.AspNet.Hosting --config hosting.json"
+  },
+
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  },
+
+  "publishExclude": [
+    "node_modules",
+    "bower_components",
+    "**.xproj",
+    "**.user",
+    "**.vspscc"
+  ],
+  "exclude": [
+    "wwwroot",
+    "node_modules",
+    "bower_components"
+  ]
+}

--- a/src/IdentityServer4.AccessTokenValidation/AccessTokenValidationApplicationBuilderExtensions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/AccessTokenValidationApplicationBuilderExtensions.cs
@@ -1,0 +1,74 @@
+﻿using IdentityServer4.AccessTokenValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNet.Builder
+{
+    public static class AccessTokenValidationApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder UseIdentityServerBearerTokenAuthentication(this IApplicationBuilder app, IdentityServerBearerTokenOptions options)
+        {
+            return UseIdentityServerBearerTokenAuthentication(app, options, null);
+        }
+
+        public static IApplicationBuilder UseIdentityServerBearerTokenAuthentication(this IApplicationBuilder app, IdentityServerBearerTokenOptions options, IntrospectionEndpointOptions introspectionEndpointOptions)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (introspectionEndpointOptions != null)
+            {
+                var alignedIntrospectionEndpointOptions = AlignIntrospectionEndpointOptions(options, introspectionEndpointOptions);
+                app.UseIntrospectionEndpointAuthentication(alignedIntrospectionEndpointOptions);
+            }
+            else
+            {
+                app.UseJwtBearerAuthentication(options);
+            }
+
+            if (options.RequiredScopes.Any())
+            {
+                IEnumerable<string> scopes = options.RequiredScopes.Concat(new[] { introspectionEndpointOptions.ScopeName });
+                app.UseMiddleware<ScopeRequirementMiddleware>(scopes);
+            }
+
+            return app;
+        }
+
+        private static IntrospectionEndpointOptions AlignIntrospectionEndpointOptions(IdentityServerBearerTokenOptions options, IntrospectionEndpointOptions introspectionEndpointOptions)
+        {
+            introspectionEndpointOptions.Authority = introspectionEndpointOptions.Authority ?? options.Authority;
+            introspectionEndpointOptions.AutomaticAuthenticate = introspectionEndpointOptions.AutomaticAuthenticate || options.AutomaticAuthenticate;
+            introspectionEndpointOptions.AutomaticChallenge = introspectionEndpointOptions.AutomaticChallenge || options.AutomaticChallenge;
+            introspectionEndpointOptions.ClaimsIssuer = introspectionEndpointOptions.ClaimsIssuer ?? options.ClaimsIssuer;
+            introspectionEndpointOptions.PreserveAccessToken = introspectionEndpointOptions.PreserveAccessToken || options.PreserveAccessToken;
+
+            return introspectionEndpointOptions;
+        }
+
+        private static IApplicationBuilder UseIntrospectionEndpointAuthentication(this IApplicationBuilder app, IntrospectionEndpointOptions options)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            app.UseMiddleware<IntrospectionEndpointMiddleware>(options);
+
+            return app;
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/AccessTokenValidationServiceCollectionExtensions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/AccessTokenValidationServiceCollectionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using IdentityServer4.AccessTokenValidation;
+using Microsoft.AspNet.Authentication;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for setting up access token validation services in an <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class AccessTokenValidationServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds access token validation services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns> 
+        public static IServiceCollection AddAccessTokenValidation(this IServiceCollection services)
+        {
+            services.AddAuthentication();   
+            return services;
+        }
+
+        /// <summary>
+        /// Adds access token validation services to the specified <see cref="IServiceCollection" /> with 
+        /// default in-memory validation result caching.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns> 
+        /// <seealso cref="ISystemClock" />
+        /// <seealso cref="SystemClock" />
+        /// <seealso cref="IValidationResultCache" />
+        /// <seealso cref="InMemoryValidationResultCache" />
+        public static IServiceCollection AddAccessTokenValidationWithCaching(this IServiceCollection services)
+        {
+            services.AddCaching();
+            services.AddAuthentication();
+            services.TryAdd(ServiceDescriptor.Singleton<ISystemClock, SystemClock>());
+            services.TryAdd(ServiceDescriptor.Singleton<IValidationResultCache, InMemoryValidationResultCache>());
+
+            return services;
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/IdentityServer4.AccessTokenValidation.xproj
+++ b/src/IdentityServer4.AccessTokenValidation/IdentityServer4.AccessTokenValidation.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>11600df7-fc1f-4728-afb0-5bd6d90a2645</ProjectGuid>
+    <RootNamespace>IdentityServer4.AccessTokenValidation</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/IdentityServer4.AccessTokenValidation/IdentityServerBearerTokenOptions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/IdentityServerBearerTokenOptions.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Authentication.JwtBearer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    public class IdentityServerBearerTokenOptions : JwtBearerOptions, IIdentityServerBearerTokenBaseOptions
+    {
+        public IdentityServerBearerTokenOptions()
+        {
+            ValidationResultCacheDuration = TimeSpan.FromMinutes(5);
+            RequiredScopes = Enumerable.Empty<string>();
+            PreserveAccessToken = false;
+        }
+
+        public IEnumerable<string> RequiredScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to preserve the access token as a claim. Defaults to false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if access token is preserved; otherwise, <c>false</c>.
+        /// </value>
+        public bool PreserveAccessToken { get; set; }
+
+        public TimeSpan ValidationResultCacheDuration { get; set; }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Infrastructure/Abstractions/Caching/IValidationResultCache.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Infrastructure/Abstractions/Caching/IValidationResultCache.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    /// <summary>
+    /// Interface for caching then token validation result
+    /// </summary>
+    public interface IValidationResultCache
+    {
+        /// <summary>
+        /// Add a validation result
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="claims">The claims.</param>
+        /// <returns></returns>
+        Task AddAsync(string token, IEnumerable<Claim> claims, TimeSpan cacheDuration);
+
+        /// <summary>
+        /// Retrieves a validation result
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <returns></returns>
+        Task<IEnumerable<Claim>> GetAsync(string token);
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Infrastructure/Abstractions/Caching/InMemoryValidationResultCache.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Infrastructure/Abstractions/Caching/InMemoryValidationResultCache.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Security.Claims;
+using System.Linq;
+using IdentityModel;
+using Microsoft.AspNet.Authentication;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    public class InMemoryValidationResultCache : IValidationResultCache
+    {
+        private const string CacheKeyPrefix = "identityserver4:token:";
+        private readonly IMemoryCache _cache;
+        private readonly ISystemClock _clock;
+
+        public InMemoryValidationResultCache(IMemoryCache cache, ISystemClock clock)
+        {
+            if (cache == null)
+            {
+                throw new ArgumentNullException(nameof(cache));
+            }
+
+            if (clock == null)
+            {
+                throw new ArgumentNullException(nameof(clock));
+            }
+
+            _cache = cache;
+            _clock = clock;
+        }
+
+        public Task AddAsync(string token, IEnumerable<Claim> claims, TimeSpan cacheDuration)
+        {
+            var expiryClaim = claims.FirstOrDefault(c => c.Type == ClaimTypes.Expiration);
+            var cacheExpirySetting = _clock.UtcNow.Add(cacheDuration);
+
+            if (expiryClaim != null)
+            {
+                long epoch;
+                if (long.TryParse(expiryClaim.Value, out epoch))
+                {
+                    var tokenExpiresAt = epoch.ToDateTimeOffsetFromEpoch();
+                    if (tokenExpiresAt < cacheExpirySetting)
+                    {
+                        var cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(tokenExpiresAt);
+                        _cache.Set($"{CacheKeyPrefix}{token}", claims, cacheOptions);
+                    }
+                }
+            }
+            else
+            {
+                var cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(cacheExpirySetting);
+                _cache.Set($"{CacheKeyPrefix}{token}", claims, cacheOptions);
+            }
+
+            return Task.FromResult(0);
+        }
+
+        public Task<IEnumerable<Claim>> GetAsync(string token)
+        {
+            IEnumerable<string> claims = null;
+            if(_cache.TryGetValue($"{CacheKeyPrefix}{token}", out claims))
+            {
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Infrastructure/IIdentityServerBearerTokenBaseOptions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Infrastructure/IIdentityServerBearerTokenBaseOptions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    internal interface IIdentityServerBearerTokenBaseOptions
+    {
+        /// <summary>
+        /// Gets or sets the base address of identity server (required)
+        /// </summary>
+        /// <value>
+        /// The authority.
+        /// </value>
+        string Authority { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the validation result cache.
+        /// </summary>
+        /// <value>
+        /// The duration of the validation result cache. The default is 5 minutes.
+        /// </value>
+        TimeSpan ValidationResultCacheDuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to preserve the access token as a claim. Defaults to false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if access token is preserved; otherwise, <c>false</c>.
+        /// </value>
+        bool PreserveAccessToken { get; set; }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Infrastructure/StringExtensions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Infrastructure/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace IdentityServer4.AccessTokenValidation
+{
+    internal static class StringExtensions
+    {
+        public static string EnsureTrailingSlash(this string input)
+        {
+            if (!input.EndsWith("/"))
+            {
+                return input + "/";
+            }
+
+            return input;
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Introspection/IntrospectionEndpointHandler.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Introspection/IntrospectionEndpointHandler.cs
@@ -1,0 +1,153 @@
+﻿using IdentityModel.Client;
+using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Http.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    public class IntrospectionEndpointHandler : AuthenticationHandler<IntrospectionEndpointOptions>
+    {
+        private const string BearerAuthSchema = "Bearer";
+        private static readonly Lazy<HttpMessageHandler> _handler = new Lazy<HttpMessageHandler>(
+            () => new HttpClientHandler(), isThreadSafe: true);
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            ValidateRequirements();
+
+            // handle
+
+            AuthenticateResult result;
+
+            StringValues authorization;
+            if (Request.Headers.TryGetValue("Authorization", out authorization) == false)
+            {
+                result = AuthenticateResult.Failed("No authorization header.");
+            }
+            else
+            {
+                if (authorization.ToString().StartsWith($"{BearerAuthSchema} ", StringComparison.OrdinalIgnoreCase) == false)
+                {
+                    return AuthenticateResult.Failed("Invalid or unsopported authentication schema.");
+                }
+                else
+                {
+                    var token = authorization.ToString().Substring($"{BearerAuthSchema} ".Length).Trim();
+                    if (string.IsNullOrEmpty(token))
+                    {
+                        result = AuthenticateResult.Failed("No bearer token.");
+                    }
+                    else
+                    {
+                        result = await HandleImplAsync(token);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private void ValidateRequirements()
+        {
+            if (string.IsNullOrWhiteSpace(Options.Authority))
+            {
+                throw new InvalidOperationException("Authority must be set to use validation endpoint.");
+            }
+        }
+
+        private async Task<AuthenticateResult> HandleImplAsync(string token)
+        {
+            AuthenticateResult result;
+
+            var cache = Context.RequestServices.GetService<IValidationResultCache>();
+            if (cache != null)
+            {
+                var cachedClaims = await cache.GetAsync(token);
+                if (cachedClaims != null)
+                {
+                    result = AuthenticateResult.Success(IssueTicket(cachedClaims));
+                }
+                else
+                {
+                    result = await HandleRemoteAsync(token, cache);
+                }
+            }
+            else
+            {
+                result = await HandleRemoteAsync(token, null);
+            }
+
+            return result;
+        }
+
+        private async Task<AuthenticateResult> HandleRemoteAsync(string token, IValidationResultCache cache)
+        {
+            AuthenticateResult result;
+
+            var introspectionEndpoint = $"{Options.Authority.EnsureTrailingSlash()}connect/introspect";
+            var handler = Options.BackchannelHttpHandler ?? _handler.Value;
+            IntrospectionClient introspectionClient = string.IsNullOrEmpty(Options.ScopeName) == false
+                ? new IntrospectionClient(introspectionEndpoint, Options.ScopeName, Options.ScopeSecret ?? string.Empty, handler)
+                : new IntrospectionClient(introspectionEndpoint, innerHttpMessageHandler: handler);
+
+            IntrospectionResponse response;
+            try
+            {
+                response = await introspectionClient.SendAsync(new IntrospectionRequest { Token = token });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Exception while contacting introspection endpoint", ex);
+                return AuthenticateResult.Failed(ex);
+            }
+
+            if (response.IsError)
+            {
+                Logger.LogError("Error returned from introspection endpoint: {introspectionRequestError}", response.Error);
+                result = AuthenticateResult.Failed(response.Error);
+            }
+            else if (!response.IsActive)
+            {
+                Logger.LogVerbose("Inactive token: {inactiveToken}", token);
+                result = AuthenticateResult.Failed("Inactive token");
+            }
+            else
+            {
+                var claims = new List<Claim>();
+                foreach (var claim in response.Claims)
+                {
+                    if (!string.Equals(claim.Item1, "active", StringComparison.Ordinal))
+                    {
+                        claims.Add(new Claim(claim.Item1, claim.Item2));
+                    }
+                }
+
+                if (cache != null)
+                {
+                    await cache.AddAsync(token, claims, Options.ValidationResultCacheDuration);
+                }
+
+                result = AuthenticateResult.Success(IssueTicket(claims));
+            }
+
+            return result;
+        }
+
+        private AuthenticationTicket IssueTicket(IEnumerable<Claim> claims)
+        {
+            var identity = new ClaimsIdentity(claims, Options.AuthenticationScheme);
+
+            return new AuthenticationTicket(
+                new ClaimsPrincipal(identity),
+                new AuthenticationProperties(),
+                Options.AuthenticationScheme);
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Introspection/IntrospectionEndpointMiddleware.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Introspection/IntrospectionEndpointMiddleware.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNet.Authentication;
+using Microsoft.AspNet.Builder;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.WebEncoders;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    public class IntrospectionEndpointMiddleware : AuthenticationMiddleware<IntrospectionEndpointOptions>
+    {
+        public IntrospectionEndpointMiddleware(RequestDelegate next, IntrospectionEndpointOptions options, IUrlEncoder urlEncoder, ILoggerFactory loggerFactory)
+            : base(next, options, loggerFactory, urlEncoder)
+        {
+        }
+
+        protected override AuthenticationHandler<IntrospectionEndpointOptions> CreateHandler()
+        {
+            return new IntrospectionEndpointHandler();
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/Introspection/IntrospectionEndpointOptions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/Introspection/IntrospectionEndpointOptions.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNet.Authentication;
+using System;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    public class IntrospectionEndpointOptions : RemoteAuthenticationOptions, IIdentityServerBearerTokenBaseOptions
+    {
+        public IntrospectionEndpointOptions()
+        {
+            AuthenticationScheme = "Bearer";
+            ValidationResultCacheDuration = TimeSpan.FromMinutes(5);
+        }
+
+        /// <summary>
+        /// Gets or sets the scope name for accessing the introspection endpoint. This will also be used
+        /// for the scope validation.
+        /// </summary>
+        /// <value>
+        /// The scope name.
+        /// </value>
+        public string ScopeName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scope secret for accessing the introspection endpoint.
+        /// </summary>
+        /// <value>
+        /// The scope secret.
+        /// </value>
+        public string ScopeSecret { get; set; }
+
+        public string Authority { get; set; }
+
+        public TimeSpan ValidationResultCacheDuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to preserve the access token as a claim. Defaults to false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if access token is preserved; otherwise, <c>false</c>.
+        /// </value>
+        public bool PreserveAccessToken { get; set; }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/ScopeRequirement/ScopeRequirementMiddleware.cs
+++ b/src/IdentityServer4.AccessTokenValidation/ScopeRequirement/ScopeRequirementMiddleware.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IdentityServer4.AccessTokenValidation
+{
+    /// <summary>
+    /// Middleware to check for scope claims in access token
+    /// </summary>
+    public class ScopeRequirementMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IEnumerable<string> _scopes;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScopeRequirementMiddleware"/> class.
+        /// </summary>
+        /// <param name="next">The next midleware.</param>
+        /// <param name="scopes">The scopes.</param>
+        public ScopeRequirementMiddleware(RequestDelegate next, IEnumerable<string> scopes, ILogger<ScopeRequirementMiddleware> logger)
+        {
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            if (scopes == null)
+            {
+                throw new ArgumentNullException(nameof(scopes));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            _next = next;
+            _scopes = scopes;
+            _logger = logger;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            // if no token was sent - no need to validate scopes
+            var principal = context.User;
+
+            if (principal == null || principal.Identity == null | !principal.Identity.IsAuthenticated)
+            {
+                return _next.Invoke(context);
+            }
+            else if (ScopesFound(context))
+            {
+                return _next.Invoke(context);
+            }
+            else
+            {
+                context.Response.StatusCode = 403;
+                context.Response.Headers.Add("WWW-Authenticate", new[] { "Bearer error=\"insufficient_scope\"" });
+
+                return Task.FromResult(0);
+            }
+        }
+
+        private bool ScopesFound(HttpContext context)
+        {
+            var scopeClaims = context.User.FindAll("scope");
+
+            if (scopeClaims == null || !scopeClaims.Any())
+            {
+                return false;
+            }
+
+            foreach (var scope in scopeClaims)
+            {
+                if (_scopes.Contains(scope.Value, StringComparer.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/IdentityServer4.AccessTokenValidation/project.json
+++ b/src/IdentityServer4.AccessTokenValidation/project.json
@@ -1,23 +1,29 @@
 {
   "description": "ASP.NET 5 Middleware to validate access tokens from IdentityServer",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "repository": {
     "type": "git"
   },
 
   "dependencies": {
-    "Microsoft.AspNet.Authentication": "1.0.0-rc1-final"
+    "Microsoft.AspNet.Authentication": "1.0.0-rc1-final",
+    "Microsoft.Extensions.Caching.Memory": "1.0.0-rc1-final",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc1-final",
+    "Microsoft.AspNet.Authentication.JwtBearer":  "1.0.0-rc1-final",
+    "IdentityModel": "2.0.0-alpha1"
   },
 
   "frameworks": {
-    "net451": {
+    "dnx451": {
       "frameworkAssemblies": {
         "System.Net.Http": ""
       }
     },
 
-    "dotnet5.4": {
-      "System.Net.Http": "4.0.1-beta-23516"
+    "dnxcore50": {
+      "dependencies": {
+        "System.Net.Http": "4.0.1-beta-23516"
+      }
     }
   }
 }

--- a/src/IdentityServer4.AccessTokenValidation/project.json
+++ b/src/IdentityServer4.AccessTokenValidation/project.json
@@ -1,0 +1,23 @@
+{
+  "description": "ASP.NET 5 Middleware to validate access tokens from IdentityServer",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git"
+  },
+
+  "dependencies": {
+    "Microsoft.AspNet.Authentication": "1.0.0-rc1-final"
+  },
+
+  "frameworks": {
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Net.Http": ""
+      }
+    },
+
+    "dotnet5.4": {
+      "System.Net.Http": "4.0.1-beta-23516"
+    }
+  }
+}

--- a/tests/IdentityServer4.AccessTokenValidation.Tests/DummyTests.cs
+++ b/tests/IdentityServer4.AccessTokenValidation.Tests/DummyTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer4.AccessTokenValidation.Tests
+{
+    public class DummyTests
+    {
+        [Fact]
+        public void ShouldPass()
+        {
+            Assert.True(true);
+        }
+    }
+}

--- a/tests/IdentityServer4.AccessTokenValidation.Tests/IdentityServer4.AccessTokenValidation.Tests.xproj
+++ b/tests/IdentityServer4.AccessTokenValidation.Tests/IdentityServer4.AccessTokenValidation.Tests.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>26abde45-0f06-41c2-b38e-86ac35db38c3</ProjectGuid>
+    <RootNamespace>IdentityServer4.AccessTokenValidation.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/IdentityServer4.AccessTokenValidation.Tests/project.json
+++ b/tests/IdentityServer4.AccessTokenValidation.Tests/project.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+
+  "dependencies": {
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204",
+    "Microsoft.AspNet.Authentication": "1.0.0-rc1-final"
+  },
+
+  "frameworks": {
+    "dnx451": {
+      "frameworkAssemblies": {
+        "System.Net.Http": ""
+      }
+    },
+
+    "dnxcore50": {
+      "System.Net.Http": "4.0.1-beta-23516"
+    }
+  },
+
+  "commands": {
+      "test": "xunit.runner.dnx"
+  }
+}

--- a/tests/IdentityServer4.AccessTokenValidation.Tests/project.json
+++ b/tests/IdentityServer4.AccessTokenValidation.Tests/project.json
@@ -15,7 +15,9 @@
     },
 
     "dnxcore50": {
-      "System.Net.Http": "4.0.1-beta-23516"
+      "dependencies": {
+        "System.Net.Http": "4.0.1-beta-23516"
+      }
     }
   },
 


### PR DESCRIPTION
This is the initial version of access token validation for Identity Server. I written any tests on it as I am not entirely sure if I implemented it correctly and in an expected way. This pull request is mainly to get more feedback. There are a few obvious missing parts:

 - [ ] Complete `InMemoryValidationResultCache.GetAsync` implementation (slipped :disappointed:)
 - [ ] Preserve access token implementation.
 - [ ] Working sample.
 - [ ] Extensive logging.
 - [ ] Tests.