### PR TITLE
Added initial build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ FakesAssemblies/
 
 # ASP.NET 5
 project.lock.json
+nuget.exe

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,23 @@
+@echo off
+cd %~dp0
+
+SETLOCAL
+SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
+
+IF EXIST %CACHED_NUGET% goto copynuget
+echo Downloading latest version of NuGet.exe...
+IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '%CACHED_NUGET%'"
+
+:copynuget
+IF EXIST .nuget\nuget.exe goto restore
+md .nuget
+copy %CACHED_NUGET% .nuget\nuget.exe > nul
+
+:restore
+IF EXIST packages\psake goto run
+.nuget\NuGet.exe install psake -ExcludeVersion -o packages -nocache
+
+:run
+:: Get Psake to Return Non-Zero Return Code on Build Failure (https://github.com/psake/psake/issues/58)
+@powershell -NoProfile -ExecutionPolicy unrestricted -command "&{ Import-Module .\packages\psake\tools\psake.psm1; Invoke-Psake .\scripts\default.ps1 -parameters @{'configuration'='Release'}; exit !($psake.build_success) }"

--- a/scripts/core/utils.ps1
+++ b/scripts/core/utils.ps1
@@ -1,0 +1,17 @@
+## http://stackoverflow.com/questions/1499466/powershell-equivalent-of-linq-any
+function Test-Any {
+    [CmdletBinding()]
+    param($EvaluateCondition,
+        [Parameter(ValueFromPipeline = $true)] $ObjectToTest)
+    begin {
+        $any = $false
+    }
+    process {
+        if (-not $any -and (& $EvaluateCondition $ObjectToTest)) {
+            $any = $true
+        }
+    }
+    end {
+        $any
+    }
+}

--- a/scripts/default.ps1
+++ b/scripts/default.ps1
@@ -1,0 +1,90 @@
+properties {
+    $configuration = $configuration
+}
+
+Include ".\core\utils.ps1"
+
+$projectFileName = "project.json"
+$solutionRoot = (get-item $PSScriptRoot).parent.fullname
+$artifactsRoot = "$solutionRoot\artifacts"
+$artifactsBuildRoot = "$artifactsRoot\build"
+$artifactsTestRoot = "$artifactsRoot\test"
+$artifactsPackagesRoot = "$artifactsRoot\packages"
+$srcRoot = "$solutionRoot\src"
+$testsRoot = "$solutionRoot\test"
+$globalFilePath = "$solutionRoot\global.json"
+$appProjects = Get-ChildItem "$srcRoot\**\$projectFileName" | foreach { $_.FullName }
+$testProjects = Get-ChildItem "$testsRoot\**\$projectFileName" | foreach { $_.FullName }
+$packableProjectDirectories = @("$srcRoot\IdentityServer4.AccessTokenValidation")
+
+task default -depends TestParams, Setup, Build, RunTests, Pack
+
+task TestParams { 
+	Assert ($configuration -ne $null) '$configuration should not be null'
+}
+
+task Setup {
+    if((test-path $globalFilePath) -eq $false) {
+        throw "global.json doesn't exists. globalFilePath: $globalFilePath"
+    }
+	
+	$globalSettingsObj = (get-content $globalFilePath) -join "`n" | ConvertFrom-Json
+	$hasSdk = $globalSettingsObj | Get-Member | 
+		where { $_.MemberType -eq "NoteProperty" } | 
+		Test-Any { $_.Name -eq "sdk" }
+		
+	if($hasSdk) {
+		$hasVersion = $globalSettingsObj.sdk | Get-Member | 
+			where { $_.MemberType -eq "NoteProperty" } | 
+			Test-Any { $_.Name -eq "version" }
+			
+		if($hasVersion) {
+			$runtimeVersion = $globalSettingsObj.sdk.version;
+			Write-Output "Setting runtime v$runtimeVersion as active runtime"
+			dnvm use $globalSettingsObj.sdk.version
+		}
+		else {
+			throw "global.json doesn't contain sdk version."
+		}
+	}
+	else {
+		throw "global.json doesn't contain sdk information."
+	}
+}
+
+task Build -depends Restore, Clean {
+	
+	$appProjects | foreach {
+		dnu build "$_" --configuration $configuration --out "$artifactsBuildRoot"
+    }
+    
+    $testProjects | foreach {
+		dnu build "$_" --configuration $configuration --out "$artifactsBuildRoot"
+    }
+}
+
+task RunTests -depends Restore, Clean {
+	$testProjects | foreach {
+		Write-Output "Running tests for '$_'"
+		dnx --project "$_" Microsoft.Dnx.ApplicationHost test
+	}
+}
+
+task Pack -depends Restore, Clean {
+	$packableProjectDirectories | foreach {
+		dnu pack "$_" --configuration $configuration --out "$artifactsPackagesRoot" --quiet
+	}
+}
+
+task Restore {
+	@($srcRoot, $testsRoot) | foreach {
+        dnu restore "$_"
+    }
+}
+
+task Clean {
+    $directories = $(Get-ChildItem "$solutionRoot\artifacts*"),`
+        $(Get-ChildItem "$solutionRoot\**\**\bin")
+		
+    $directories | foreach ($_) { Remove-Item $_.FullName -Force -Recurse }
+}


### PR DESCRIPTION
You can run the build by running `build.cmd` file. It's based on psake. It does the following:

 - Cleans stuff.
 - Restores
 - Builds stuff under `src` and `test`
 - Run test projects under `test` directory.
 - Packs

It puts stuff under `./artifacts` directory. Packages will end up under `artifacts/packages/Release`.

A few things that might be worth looking into/improving:

 - We need a way to identity the build version somehow and patch the `project.json` files so that `dnu pack` would pick that up and produce the nuget packages with correct versions.
 - <strike>Do you want to build projects under `samples` as part of CI process?</strike>
 - Depending on what it does (which you might guess I don't exactly know), we might wanna run `dnu restore` with `--lock` switch. However, as this project will only produce libraries as NuGet packages, the following might not be an issue but I am not sure.