### PR TITLE
fix UseIdentityServerAuthentication extension method to avoid exception

### DIFF
--- a/src/IdentityServer4.AccessTokenValidation/IdentityServerAuthenticationExtensions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/IdentityServerAuthenticationExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Builder
 
         public static IApplicationBuilder UseIdentityServerAuthentication(this IApplicationBuilder app, CombinedAuthenticationOptions options)
         {
-            app.UseMiddleware<IdentityServerAuthenticationMiddleware>(options);    
+            app.UseMiddleware<IdentityServerAuthenticationMiddleware>(app, options);    
 
             if (options.ScopeValidationOptions.AllowedScopes.Any())
             {


### PR DESCRIPTION
The exception info:
An unhandled exception of type 'System.InvalidOperationException' occurred in Microsoft.AspNetCore.Http.Abstractions.dll
Additional information: Unable to resolve service for type 'Microsoft.AspNetCore.Builder.IApplicationBuilder' while attempting to activate 'IdentityServer4.AccessTokenValidation.IdentityServerAuthenticationMiddleware'.

Because of lack of a parameter in "app.UseMiddleware<IdentityServerAuthenticationMiddleware>" function,  just add it then work well