### PR TITLE
Adding NET452 conditional code to force HttpClient to support secure connections with TLS.

### DIFF
--- a/src/IdentityServer4.AccessTokenValidation/IdentityServerAuthenticationMiddleware.cs
+++ b/src/IdentityServer4.AccessTokenValidation/IdentityServerAuthenticationMiddleware.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace IdentityServer4.AccessTokenValidation
@@ -56,7 +57,13 @@ namespace IdentityServer4.AccessTokenValidation
 
         public async Task Invoke(HttpContext context)
         {
-            var token = _options.TokenRetriever(context.Request);
+
+#if NET452
+			// The following line forces HttpClient to negotiate with latest versions of TLS when targeting your build at NET452
+			System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+#endif
+
+			var token = _options.TokenRetriever(context.Request);
             bool removeToken = false;
 
             try


### PR DESCRIPTION
Encountered this bug when targeting NET452 using both IdentityServer4 and IdentityServer4.AccessTokenValidation.

However the problem goes beyond this use case, as the OIDC discovery document retrieval would also fail when served from an IS4 service targeting 452, and called by a service that is targeting 452.

The line of code I added resolves this bug.

(NOTE: Sorry about the tab issue on the line of code following my additions.  I'm not sure why that is there because it is not locally.  Might be encoding used in the source file I guess.)