### PR TITLE
CacheKeyPrefix property is added to IdentityServerAuthenticationOptions

### DIFF
--- a/src/IdentityServer4.AccessTokenValidation/IdentityServer4.AccessTokenValidation.csproj
+++ b/src/IdentityServer4.AccessTokenValidation/IdentityServer4.AccessTokenValidation.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="3.3.0" />
+    <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="3.4.1" />
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.0" PrivateAssets="all" />
     
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.0.0" />

--- a/src/IdentityServer4.AccessTokenValidation/IdentityServerAuthenticationOptions.cs
+++ b/src/IdentityServer4.AccessTokenValidation/IdentityServerAuthenticationOptions.cs
@@ -85,6 +85,11 @@ namespace IdentityServer4.AccessTokenValidation
         public TimeSpan CacheDuration { get; set; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
+        /// Specifies the prefix of the cache key (token).
+        /// </summary>
+        public string CacheKeyPrefix { get; set; } = string.Empty;
+
+        /// <summary>
         /// specifies whether the token should be saved in the authentication properties
         /// </summary>
         public bool SaveToken { get; set; } = true;
@@ -237,6 +242,7 @@ namespace IdentityServer4.AccessTokenValidation
 
             introspectionOptions.EnableCaching = EnableCaching;
             introspectionOptions.CacheDuration = CacheDuration;
+            introspectionOptions.CacheKeyPrefix = CacheKeyPrefix;
 
             introspectionOptions.DiscoveryTimeout = BackChannelTimeouts;
             introspectionOptions.IntrospectionTimeout = BackChannelTimeouts;


### PR DESCRIPTION
PR based on: 
https://github.com/IdentityModel/IdentityModel.AspNetCore.OAuth2Introspection/pull/34