### PR TITLE
upgrade Bullseye, SimpleExec, and Minver

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0" />
+    <PackageReference Include="Bullseye" Version="3.3.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.4" />
-    <PackageReference Include="SimpleExec" Version="6.1.0" />
+    <PackageReference Include="SimpleExec" Version="6.2.0" />
   </ItemGroup>
   
 </Project>

--- a/src/IdentityServer4.AccessTokenValidation.csproj
+++ b/src/IdentityServer4.AccessTokenValidation.csproj
@@ -38,6 +38,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     
-    <PackageReference Include="minver" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="minver" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**What issue does this PR address?**

Upgrades build tools:

- Bullseye: 3.0.0 → 3.3.0
- SimpleExec: 6.1.0 → 6.2.0
- Minver: 2.0.0 → 2.2.0

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- ~Unit Tests for the changes have been added (for bug fixes / features)~

**Other information**:
